### PR TITLE
Adds getContainer to ResolveContext

### DIFF
--- a/src/ResolveContext.php
+++ b/src/ResolveContext.php
@@ -62,4 +62,14 @@ class ResolveContext implements ResourceAwareInterface
 	{
 		return $this->multiton;
 	}
+
+	/**
+	 * Returns the Container
+	 *
+	 * @return Container
+	 */
+	public function getContainer()
+	{
+		return $this->container;
+	}
 }

--- a/tests/unit/ResolveContextTest.php
+++ b/tests/unit/ResolveContextTest.php
@@ -29,5 +29,7 @@ class ResolveContextTest extends Test
 
 		$this->assertEquals('name', $context->getName());
 		$this->assertTrue($context->isMultiton());
+
+		$this->assertSame($container, $context->getContainer());
 	}
 }


### PR DESCRIPTION
In some cases the container itself needs to be injected. In these cases the container itself is needed, which is only available from the context.
